### PR TITLE
Fix showChatButton

### DIFF
--- a/src/pages/ListingDetails.tsx
+++ b/src/pages/ListingDetails.tsx
@@ -130,7 +130,7 @@ const ListingDetails = () => {
     </div>;
   }
 
-  const showChatButton = user && listing.user_id !== user.id;
+  const showChatButton = listing.user_id !== user?.id;
 
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
## Summary
- render ChatDialog when `user` is null so the toast can prompt a sign in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d9b1da1b8832cab60a3c82524fa75